### PR TITLE
Add custom atlantis image

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,15 @@
+FROM ghcr.io/runatlantis/atlantis:v0.19.6
+
+LABEL org.opencontainers.image.source="https://github.com/infra-pipeline-hackathon22/hackathon-atlantis"
+
+USER root
+
+# Install python/pip
+ENV PYTHONUNBUFFERED=1
+RUN apk add --update --no-cache python3 && ln -sf python3 /usr/bin/python
+RUN python3 -m ensurepip
+ADD requirements.txt /tmp
+RUN pip3 install --no-cache --upgrade pip setuptools && pip3 install -r /tmp/requirements.txt
+
+
+USER atlantis

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,14 @@
+# Building the image
+
+1. Log into the ghcr per [these instructions](infra-pipeline-hackathon22/python-atlantis:v0.0.1)
+2. Go to the `docker` subdirectory
+3. Run the following:
+```
+IMAGE="ghcr.io/infra-pipeline-hackathon22/python-atlantis"
+TAG="v0.0.1"
+docker build -f Dockerfile -t ${IMAGE}:${TAG} . 
+```
+4. Push image
+```
+docker push ${IMAGE};${TAG}
+```

--- a/docker/requirements.txt
+++ b/docker/requirements.txt
@@ -1,0 +1,1 @@
+requests


### PR DESCRIPTION
with python and instructions

You can now run python on the images! 

If there is a package that you need, update requirements.txt and follow the README.md in the docker directory

<img width="631" alt="image" src="https://user-images.githubusercontent.com/53842732/180128971-271cb4fc-f99b-4f89-9ca6-4e7f444a5ffa.png">
